### PR TITLE
fix: update createChangesetSpec

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -36,7 +36,8 @@ export const createCampaignSpec = async ({
                         `
         mutation CreateChangesetSpec($changesetSpec: String!) {
             createChangesetSpec(changesetSpec: $changesetSpec) {
-                id
+                ... on HiddenChangesetSpec { id }
+                ... on VisibleChangesetSpec { id }
             }
         }`,
                         { changesetSpec: JSON.stringify(changesetSpec) }


### PR DESCRIPTION
Update the query for `createChangesetSpec`

This was causing the query to fail.