### PR TITLE
ci: update to actions/checkout@v3

### DIFF
--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -5,7 +5,7 @@ jobs:
   index:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Update to actions/checkout@v3 to avoid deprecation warning

### Test plan
Created as part of batch change: [_Created by Sourcegraph batch change `sourcegraph-operator-dax/Upgrade_actions_checkout_v2-v3`._](https://sourcegraph.sourcegraph.com/users/sourcegraph-operator-dax/batch-changes/Upgrade_actions_checkout_v2-v3)